### PR TITLE
Add libffi to compiler flags

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -20,7 +20,11 @@ let () =
       match C.Pkg_config.get c with
       | None -> default
       | Some pc ->
-        Option.value (C.Pkg_config.query pc ~package:"gobject-introspection-1.0") ~default
+        let libffi = Option.value_exn (C.Pkg_config.query pc ~package:"libffi") in
+        let gobject = Option.value (C.Pkg_config.query pc ~package:"gobject-introspection-1.0") ~default in
+        let  module P = C.Pkg_config in
+        { P.libs = libffi.P.libs @ gobject.P.libs
+        ; cflags = libffi.P.libs @ gobject.P.libs }
     in
 
     write_sexp "c_flags.sexp"         (sexp_of_list sexp_of_string conf.libs);


### PR DESCRIPTION
When using ctypes.foreign, you should compile your code against libffi. I didn't
do it properly in this commit, the way you did it for gobject. But you get the
idea of what has to be done.